### PR TITLE
Fix autoplay video on low power mode

### DIFF
--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -44,6 +44,11 @@ const Main = forwardRef((props, ref) => {
     if (isToggleOpen) refContainer.current.click();
   }
 
+  const videoRef = useRef(null);
+  const [isLPM, setIsLPM] = useState(true);
+  // If the video successfully plays, it's not on low power mode
+  useEffect(() => videoRef.current.play().then(() => {setIsLPM(false)}), []);
+
   return (
     <div>
       <div>
@@ -51,7 +56,9 @@ const Main = forwardRef((props, ref) => {
           onClick={closeToggle}
           style={{ position: "relative", width: "100%" }}
         >
+          {isLPM && <img className="BackgroundVideo Overlay" src={homeBackgroundPoster} />}
           <video
+            ref={videoRef}
             src={homeBackground}
             className="BackgroundVideo Overlay"
             type="video/mov"
@@ -59,6 +66,7 @@ const Main = forwardRef((props, ref) => {
             loop
             autoPlay
             muted
+            style={isLPM ? {display: "none"} : undefined}
             poster={homeBackgroundPoster}
           />
           <div className="Overlay DarkOverlay" />


### PR DESCRIPTION
The background video does not autoplay on an iPhone on Low Power Mode and instead shows a play button:

<img src="https://user-images.githubusercontent.com/45152028/233090511-a4dc9004-b1da-47a2-a31d-b2f89b6a67c0.jpg" width="400" />

It seems that Apple blocks the video from being played in any way other than a user tap, so if the user is on Low Power Mode, these changes will just show the background poster image:

<img src="https://user-images.githubusercontent.com/45152028/233093196-7af4383a-4209-400b-891d-fd34c3d52fa4.jpg" width="400" />

The video should still autoplay otherwise.