### PR TITLE
Fix console error

### DIFF
--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -11,14 +11,7 @@ import "../../hamburgers.css";
 import homeBackground from "../../assets/home-background.mp4";
 import homeBackgroundPoster from '../../assets/home-background-poster.jpg';
 
-const bodyScrollLock = require("body-scroll-lock");
-const disableBodyScroll = bodyScrollLock.disableBodyScroll;
-const enableBodyScroll = bodyScrollLock.enableBodyScroll;
-
 const Main = forwardRef((props, ref) => {
-  const refContainer = useRef(null);
-  const [isToggleOpen, setIsToggleOpen] = useState(false);
-
   useImperativeHandle(ref, () => ({
     scrollTo(scrollPath) {
       scroller.scrollTo(scrollPath, {
@@ -29,26 +22,16 @@ const Main = forwardRef((props, ref) => {
   }));
 
   useEffect(() => {
-    if (isToggleOpen) disableBodyScroll(refContainer.current);
-    else enableBodyScroll(refContainer.current);
-  }, [isToggleOpen]);
-
-  useEffect(() => {
     scroller.scrollTo(props.scrollGoal, {
       duration: 300,
       offset: -80,
     });
   }, [props.scrollGoal]);
 
-  function closeToggle() {
-    if (isToggleOpen) refContainer.current.click();
-  }
-
   return (
     <div>
       <div>
         <div
-          onClick={closeToggle}
           style={{ position: "relative", width: "100%" }}
         >
           <video


### PR DESCRIPTION
It seems that there is some unused code in `Main.js` that was used for a navbar toggle at some point. However, `setIsToggleOpen` is never used and `refContainer` is never added to an element so I don't think this code is used at all. There's some similar code in `LocalNavbar.js` so I'm guessing it was moved there at some point.

These changes also fix the console error "enableBodyScroll unsuccessful - targetElement must be provided when calling enableBodyScroll on IOS devices." which happens because `refContainer` is used as the `targetElement` for `enableBodyScroll` in `Main.js`, but the ref is never added to a DOM element.