### PR TITLE
Switch links to react-router links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,9 +18,10 @@ import { linkify } from "./helpers";
 function App() {
   const [scrollGoal, setScrollGoal] = useState("");
   const mainRef = useRef();
+  const otherPages = ["/expertise", "/jpabadir"];
 
   function updateScrollPath(path) {
-    if (window.location.pathname !== "/expertise" && !window.location.pathname.includes("resources")) {
+    if (!otherPages.includes(window.location.pathname) && !window.location.pathname.includes("resources")) {
       mainRef.current.scrollTo(path);
     } else {
       setScrollGoal(path);
@@ -33,8 +34,8 @@ function App() {
         <LocalNavbar scrollHandler={updateScrollPath} />
         <Routes>
           <Route path="/" element={<Main ref={mainRef} scrollGoal={scrollGoal} />} />
-          <Route path="expertise" element={<Expertise />} />
-          <Route path="jpabadir" element={<Jpabadir />} />
+          <Route path="expertise" element={<Expertise scrollHandler={updateScrollPath} />} />
+          <Route path="jpabadir" element={<Jpabadir scrollHandler={updateScrollPath} />} />
           <Route path="clients" element={<div className="StandalonePageParent" style={{ fontSize: '18px' }}><Outlet /></div>}>
             <Route path="proximy" element={<Proximy />} />
             <Route path="midstride" element={<Midstride />} />

--- a/src/components/Expertise/Expertise.js
+++ b/src/components/Expertise/Expertise.js
@@ -1,5 +1,6 @@
 import { items as expertiseItems, tagColors } from './expertise-items';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -12,7 +13,7 @@ import TableSortLabel from '@mui/material/TableSortLabel';
 import { Row, Col, Container } from 'react-bootstrap'
 import { MdKeyboardArrowLeft } from "react-icons/md";
 
-export default function Expertise() {
+export default function Expertise(props) {
   useEffect(() => {
     window.scrollTo(0, 0)
   })
@@ -75,7 +76,7 @@ export default function Expertise() {
         <Row className='d-flex justify-content-center'>
           <Col style={{ maxWidth: '1700px' }}>
             <div className='d-flex'>
-              <a href="/" style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black', fontSize: '22px' }} className='my-3'><MdKeyboardArrowLeft color="red" className='me-4' />About us</a>
+              <Link to="/" onClick={() => props.scrollHandler("about")} style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black', fontSize: '22px' }} className='my-3'><MdKeyboardArrowLeft color="red" className='me-4' />About us</Link>
             </div>
           </Col>
           <hr style={{ color: 'lightgrey' }} className='p-0 m-0' />

--- a/src/components/Jpabadir/Jpabadir.js
+++ b/src/components/Jpabadir/Jpabadir.js
@@ -1,12 +1,17 @@
-import React, { useState, useLayoutEffect} from 'react';
+import React, { useState, useLayoutEffect, useEffect } from 'react';
 import './Jpabadir.css';
 import { Row, Col, Container } from 'react-bootstrap'
+import { Link } from 'react-router-dom';
 import JP from "../../assets/jp-headshot.jpg";
 import { MdKeyboardArrowRight, MdKeyboardArrowLeft } from "react-icons/md";
 import { SiLinkedin, } from "react-icons/si"
 import { AiFillGithub } from "react-icons/ai"
 
-function Jpabadir() {
+function Jpabadir(props) {
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  });
+  
   const [isMobile, setIsMobile] = useState(false);
 
   useLayoutEffect(() => {
@@ -36,7 +41,7 @@ function Jpabadir() {
         <Row className='d-flex justify-content-center'>
           <Col style={{ maxWidth: '1700px' }}>
             <div className='d-flex'>
-              <a href="/" style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black', fontSize: '22px' }} className='my-3'><MdKeyboardArrowLeft color="red" className='me-4' />About us</a>
+              <Link to="/" onClick={() => props.scrollHandler("about")} style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black', fontSize: '22px' }} className='my-3'><MdKeyboardArrowLeft color="red" className='me-4' />About us</Link>
             </div>
           </Col>
           <hr style={{ color: 'lightgrey' }} className='p-0 m-0' />
@@ -55,7 +60,7 @@ function Jpabadir() {
               I hold a Bachelor of Computer Science from the University of British Columbia.
               <br />
               <br />
-              <a href="/expertise" style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black' }} className='ExpertiseLink'><div>Learn about our team's expertise</div><MdKeyboardArrowRight color="red" className='ms-4' style={{ transform: 'translateY(3px)' }} size='35px' /></a>
+              <Link to="/expertise" style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black' }} className='ExpertiseLink'><div>Learn about our team's expertise</div><MdKeyboardArrowRight color="red" className='ms-4' style={{ transform: 'translateY(3px)' }} size='35px' /></Link>
             </Col>
             <Col md={{ span: 4, order: 2 }} className='d-flex justify-content-center align-items-center PictureColumn'><img src={JP} className='Headshot' /></Col>
           </Row>

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -1,5 +1,6 @@
 import "./Main.css";
 import { Element, scroller } from "react-scroll";
+import { Link } from "react-router-dom";
 import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from "react";
 import About from "../About/About";
 import Home from "../Home/Home";
@@ -106,7 +107,7 @@ const Main = forwardRef((props, ref) => {
                       </div>
                     </div>
                     <div className="d-flex">
-                      <a href="/jpabadir" style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black' }} className="MeetOurFounder"><div>Meet our founder</div><MdKeyboardArrowRight color="red" style={{ transform: 'translateY(2px)' }} className="ms-3" /></a>
+                      <Link to="/jpabadir" style={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', color: 'black' }} className="MeetOurFounder"><div>Meet our founder</div><MdKeyboardArrowRight color="red" style={{ transform: 'translateY(2px)' }} className="ms-3" /></Link>
                     </div>
                   </div>
                 </Col>


### PR DESCRIPTION
- Switch links on the expertise and founder pages to react-router links (to be consistent with the expertise button in the navbar)
- Add automatic scroll to the "About us" section on the homepage when clicking the "About us" links on the expertise and founder pages